### PR TITLE
Fix for when HTTP Header 407 is not returned and quota is reached

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,6 +103,13 @@ def fetchSubtitles(proxy, token, part, imdbID=''):
             Dict['quotaReached'] = int(Datetime.TimestampFromDatetime(Datetime.Now()))
             return None
         except:
+          errorMsg = "Sorry, maximum download count for IP"
+          errorLocation = subGz.content.find(errorMsg)
+          if errorLocation != -1:
+            Log('Found \'%s\' in HTTP response. 24 Hour download quota reached!' % errorMsg)
+            Dict['quotaReached'] = int(Datetime.TimestampFromDatetime(Datetime.Now()))
+          else:
+            Log('Error when retrieving subtitle. Skipping')
           return None
 
         if downloadQuota > 0:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,15 +103,17 @@ def fetchSubtitles(proxy, token, part, imdbID=''):
             Dict['quotaReached'] = int(Datetime.TimestampFromDatetime(Datetime.Now()))
             return None
         except:
-          errorMsg = "Sorry, maximum download count for IP"
-          errorLocation = subGz.content.find(errorMsg)
-          if errorLocation != -1:
-            Log('Found \'%s\' in HTTP response. 24 Hour download quota reached!' % errorMsg)
-            Dict['quotaReached'] = int(Datetime.TimestampFromDatetime(Datetime.Now()))
-          else:
+          try:
+            errorMsg = "Sorry, maximum download count for IP"
+            errorLocation = subGz.content.find(errorMsg)
+            if errorLocation != -1:
+              Log('Found \'%s\' in HTTP response. 24 Hour download quota reached!' % errorMsg)
+              Dict['quotaReached'] = int(Datetime.TimestampFromDatetime(Datetime.Now()))
+            else:
+              Log('Error when retrieving subtitle. Skipping')
+            return None
+          except:
             Log('Error when retrieving subtitle. Skipping')
-          return None
-
         if downloadQuota > 0:
 
           subData = Archive.GzipDecompress(subGz.content)


### PR DESCRIPTION
In some scenarios the HTTP Header 407 will not be returned when quota has been reached, and an general exception will be thrown without setting quotaReached Dict.

This fixes the problem by checking the HTTP response for the magic words and setting the quotaReached Dict to 'now'.