### PR TITLE
Has to use full URL when downloading subtitle

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -95,7 +95,7 @@ def fetchSubtitles(proxy, token, part, imdbID=''):
       if subUrl not in part.subtitles[Locale.Language.Match(st['SubLanguageID'])]:
 
         try:
-          subGz = HTTP.Request(subUrl, headers={'Accept-Encoding':'gzip'})
+          subGz = HTTP.Request(st['SubDownloadLink'], headers={'Accept-Encoding':'gzip'})
           downloadQuota = int(subGz.headers['Download-Quota'])
         except Ex.HTTPError, e:
           if e.code == 407:


### PR DESCRIPTION
To avoid getting the error "Incorrect download parameters detected" when using an incomplete download URL.
Will still save as "subUrl" but use entire URL for actual download.