### PR TITLE
Don't give up when missing subs for one language

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -152,7 +152,7 @@ def fetchSubtitles(proxy, token, part, imdbID=None, filename=None, season=None, 
 
       if len(subtitleResponse) == 0:
         Log('No valid subtitles. Skipping.')
-        return None
+        continue
 
       st = sorted(subtitleResponse, key=lambda k: int(k['SubDownloadsCnt']), reverse=True) # Sort by 'most downloaded' subtitle file for current language
 


### PR DESCRIPTION
This patch fixes an error where the agent would give up and return an early
verdict when it couldn't find any subtitles for a language in the user's
preferred language list - or more specifically, when a result is returned, but
is empty. The expected behavior here should be that it instead exhausts the
list before giving up, in an effort to provide at least one set of subs.