### PR TITLE
Fix inaccurate `subtitleResponse` value when GUID/size match returns empty list

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -118,6 +118,7 @@ def fetchSubtitles(proxy, token, part, imdbID=None, filename=None, season=None, 
         subtitleResponse = proxy.SearchSubtitles(token,[{'sublanguageid':l, 'moviehash':part.openSubtitleHash, 'moviebytesize':str(part.size)}])['data']
         #Log('hash/size search result: ')
         #Log(subtitleResponse)
+        subtitleResponse = False if subtitleResponse == [] else subtitleResponse
       except:
         subtitleResponse = False
 


### PR DESCRIPTION
Ran into an issue with automatic subtitle downloading; the first episode of a season downloaded correctly, but the rest of the episodes wouldn't be downloaded. After some investigation, it appears that the `subtitleResponse` when searching by GUID and size (line 118) was returning an empty list—a _falsey_ value that doesn't == False, so all the following checks for `subtitleResponse == False` were skipped (lines 126, 135) and additional methods for finding subtitles were missed.

This one-liner fixes the issue for me. Full disclosure, I'm not a Python developer so I'm not 100% sure this is the best way to handle the issue—for example, I'm not sure if there's a deeper cause for the empty list that might need to be addressed—but at the very least this fixes the symptom for me, if not the cause itself.

Let me know if you have any other questions. I can provide my before/after logs, along with specific file and OpenSubtitles details if it'd be helpful.